### PR TITLE
Fix `json: cannot unmarshal object into Go value of type []models.Node`

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -12,6 +12,7 @@ import (
 	"marzban-exporter/models"
 	"net"
 	"net/http"
+    "net/url"
 	"sync"
 	"time"
 )
@@ -31,7 +32,7 @@ func GetAuthToken() (string, error) {
 	}
 
 	path := "/api/admin/token"
-	data := []byte(fmt.Sprintf("username=%s&password=%s", config.CLIConfig.ApiUsername, config.CLIConfig.ApiPassword))
+	data := []byte(fmt.Sprintf("username=%s&password=%s", url.QueryEscape(config.CLIConfig.ApiUsername), url.QueryEscape(config.CLIConfig.ApiPassword)))
 	httpClient := createHttpClient()
 	req, err := createRequest("POST", path, "")
 	if err != nil {


### PR DESCRIPTION
**Issue**

```
marzban-exporter-1  | 2025/04/18 17:30:52 Starting to collect metrics
marzban-exporter-1  | 2025/04/18 17:30:52 Collecting NodesStatus metrics
marzban-exporter-1  | 2025/04/18 17:30:52 Error unmarshaling response: json: cannot unmarshal object into Go value of type []models.Node
marzban-exporter-1  | 2025/04/18 17:30:52 Finished collecting NodesStatus metrics
marzban-exporter-1  | 2025/04/18 17:30:52 Collecting NodesUsage metrics
marzban-exporter-1  | 2025/04/18 17:30:52 Finished collecting NodesUsage metrics
marzban-exporter-1  | 2025/04/18 17:30:52 Collecting SystemStats metrics
marzban-exporter-1  | 2025/04/18 17:30:52 Finished collecting SystemStats metrics
marzban-exporter-1  | 2025/04/18 17:30:52 Collecting UsersStats metrics
marzban-exporter-1  | 2025/04/18 17:30:52 Fetched all users, total: 0
marzban-exporter-1  | 2025/04/18 17:30:52 Finished collecting UsersStats metrics
marzban-exporter-1  | 2025/04/18 17:30:52 Collecting CoreStatus metrics
marzban-exporter-1  | 2025/04/18 17:30:52 Finished collecting CoreStatus metrics
marzban-exporter-1  | 2025/04/18 17:30:52 Finished all metric collection
```

**Reasons**

1. Request `/api/nodes` respond: `{"detail":"Could not validate credentials"}`
2. Request `/api/admin/token` respond: `{"detail":"Incorrect username or password"}`

Just unescaped username and password fields in `data := []byte(fmt.Sprintf("username=%s&password=%s"`.
That it.